### PR TITLE
change addon-id to game.libretro.vram-test

### DIFF
--- a/game.libretro.vram-test/addon.xml.in
+++ b/game.libretro.vram-test/addon.xml.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="game.libretro.vram.test"
+<addon id="game.libretro.vram-test"
 		name="VRAM Test"
 		version="1.0.0"
 		provider-name="Libretro">


### PR DESCRIPTION
add-on `game.libretro.vram-test` is currently named `game.libretro.vram.test`, this pr fixes it